### PR TITLE
meson: use -link-defaultlib-shared with LDC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,12 +41,18 @@ mir_optim_dep = declare_dependency(
     dependencies: required_deps,
 )
 
+if meson.get_compiler('d').get_id() == 'llvm'
+    test_link_args = ['-main', '-link-defaultlib-shared']
+else
+    test_link_args = ['-main']
+endif
+
 mir_optim_test_exe = executable(meson.project_name() + '-test',
     mir_optim_src,
     include_directories: mir_optim_dir,
     d_unittest: true,
     d_module_versions: ['mir_test'],
-    link_args: '-main',
+    link_args: test_link_args,
     dependencies: required_deps,
 )
 


### PR DESCRIPTION
Fixes "Only one D shared object allowed for static runtime" error for 1.11.0 LDC