### PR TITLE
fix(least_squares): Wrap unsafe cast in trusted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   setup:
     name: 'Load job configuration'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       compilers: ${{ steps.load-config.outputs.compilers }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           const compilers = {"windows": [], "macos": [], "ubuntu": []};
           const {owner, repo} = context.repo;
           let commit_sha = context.sha;
-          if (context.eventName == "pull_request") 
+          if (context.eventName == "pull_request")
           {
             commit_sha = context.payload.pull_request.head.sha;
           }
@@ -75,11 +75,11 @@ jobs:
       matrix:
         dc: ${{ fromJSON(needs.setup.outputs.compilers).macos }}
     steps:
-      - name: Checkout repo 
+      - name: Checkout repo
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
           fetch-depth: 0
-      - name: Setup D compiler 
+      - name: Setup D compiler
         uses: dlang-community/setup-dlang@763d869b4d67e50c3ccd142108c8bca2da9df166
         with:
           compiler: ${{ matrix.dc }}
@@ -112,17 +112,17 @@ jobs:
     env:
       # Ubuntu no longer has a 32-bit version of LAPACK available, so
       # we have to drop support. :(
-      ARCH: x86_64 
+      ARCH: x86_64
     strategy:
       fail-fast: false
       matrix:
         dc: ${{ fromJSON(needs.setup.outputs.compilers).ubuntu }}
     steps:
-      - name: Checkout repo 
+      - name: Checkout repo
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
           fetch-depth: 0
-      - name: Setup D compiler 
+      - name: Setup D compiler
         uses: dlang-community/setup-dlang@763d869b4d67e50c3ccd142108c8bca2da9df166
         with:
           compiler: ${{ matrix.dc }}
@@ -137,13 +137,13 @@ jobs:
           key: ubuntu-latest-build-${{ hashFiles('**/dub.sdl', '**/dub.json') }}
           restore-keys: |
             ubuntu-latest-build-
-      - name: Build / test 
+      - name: Build / test
         run: |
           dub test --arch=$ARCH --build=unittest-cov -c unittest-blas
         shell: bash
       - name: Upload coverage data
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
-  
+
   windows:
     name: '[windows] x86_64/${{ matrix.dc }}'
     runs-on: windows-latest
@@ -158,11 +158,11 @@ jobs:
       matrix:
         dc: ${{ fromJSON(needs.setup.outputs.compilers).windows }}
     steps:
-      - name: Checkout repo 
+      - name: Checkout repo
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
           fetch-depth: 0
-      - name: Setup D compiler 
+      - name: Setup D compiler
         uses: dlang-community/setup-dlang@763d869b4d67e50c3ccd142108c8bca2da9df166
         with:
           compiler: ${{ matrix.dc }}
@@ -189,5 +189,3 @@ jobs:
         shell: bash
       - name: Upload coverage data
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
-    
-        

--- a/source/mir/optim/least_squares.d
+++ b/source/mir/optim/least_squares.d
@@ -151,7 +151,7 @@ algorithm, and an estimate of the Jacobian of `f` at x.
 The function `f` should take an input vector of length `n`, and fill an output
 vector of length `m`.
 
-The function `g` is the Jacobian of `f`, and should fill a row-major `m x n` matrix. 
+The function `g` is the Jacobian of `f`, and should fill a row-major `m x n` matrix.
 
 Throws: $(LREF LeastSquaresException)
 Params:
@@ -442,7 +442,7 @@ algorithm, and an estimate of the Jacobian of `f` at x.
 The function `f` should take an input vector of length `n`, and fill an output
 vector of length `m`.
 
-The function `g` is the Jacobian of `f`, and should fill a row-major `m x n` matrix. 
+The function `g` is the Jacobian of `f`, and should fill a row-major `m x n` matrix.
 
 Returns: optimization status.
 Params:
@@ -1201,7 +1201,7 @@ uint normalizeSafety()(uint attrs)
 auto trustedAllAttr(T)(scope return T t) @trusted
     if (isFunctionPointer!T || isDelegate!T)
 {
-    enum attrs = (functionAttributes!T & ~FunctionAttribute.system) 
+    enum attrs = (functionAttributes!T & ~FunctionAttribute.system)
         | FunctionAttribute.pure_
         | FunctionAttribute.safe
         | FunctionAttribute.nogc

--- a/source/mir/optim/least_squares.d
+++ b/source/mir/optim/least_squares.d
@@ -173,10 +173,10 @@ LeastSquaresResult!T optimize(alias f, alias g = null, alias tm = null, T)(
 {
     auto ret = optimizeLeastSquares!(f, g, tm, T)(settings, m, x, l, u);
     if (ret.status == -1)
-        throw cast()leastSquaresException_maxIterations;
+        () @trusted { throw cast()leastSquaresException_maxIterations; }();
     else
     if (ret.status < -1)
-        throw cast()leastSquaresExceptions[ret.status + 32];
+        () @trusted { throw cast()leastSquaresExceptions[ret.status + 32]; }();
     return ret;
 }
 
@@ -207,10 +207,10 @@ LeastSquaresResult!T optimize(alias f, TaskPool, T)(
 
     auto ret = optimizeLeastSquares!(f, null, tm, T)(settings, m, x, l, u);
     if (ret.status == -1)
-        throw leastSquaresException_maxIterations;
+        () @trusted { throw cast()leastSquaresException_maxIterations; }();
     else
     if (ret.status < -1)
-        throw leastSquaresExceptions[ret.status + 32];
+        () @trusted { throw cast()leastSquaresExceptions[ret.status + 32]; }();
     return ret;
 }
 


### PR DESCRIPTION
Buildkite is hitting this issue:
```
source/mir/optim/least_squares.d(242,6): Error: `@safe` function `mir.optim.least_squares.__unittest_L219_C7` cannot call `@system` function `mir.optim.least_squares.__unittest_L219_C7.optimize!((x, y)
--
  | {
  | y[0] = x[0];
  | y[1] = 2 - x[1];
  | }
  | , (x, J)
  | {
  | J[0, 0] = 1;
  | J[0, 1] = 0;
  | J[1, 0] = 0;
  | J[1, 1] = -1;
  | }
  | , null, double).optimize`
  | )(settings, 2, x, l, u);
  | ^
  | source/mir/optim/least_squares.d(176,15):        and cast from `immutable(Exception)` to `object.Exception` makes it fail to infer `@safe`
  | throw cast()leastSquaresException_maxIterations;
  | ^
```